### PR TITLE
fixed bug in polydispersity

### DIFF
--- a/structcol/model.py
+++ b/structcol/model.py
@@ -648,7 +648,7 @@ def polydisperse_form_factor(m, angles, diameters, concentration, pdi, wavelen,
     # define the range of diameters of the size distribution
     three_std_dev = 3*diameters/np.sqrt(t+1)       
     min_diameter = diameters - three_std_dev
-    min_diameter[min_diameter.magnitude < 0] = Quantity(0, diameters.units)
+    min_diameter[min_diameter.magnitude < 0] = Quantity(0.000001, diameters.units)
     max_diameter = diameters + three_std_dev
         
     F_par = np.empty([len(np.atleast_1d(diameters)), len(angles)])
@@ -702,6 +702,7 @@ def polydisperse_form_factor(m, angles, diameters, concentration, pdi, wavelen,
     # calculated as the average of each mean diameter's form factor
     f_par = np.sum(F_par, axis=0)
     f_perp = np.sum(F_perp, axis=0)
+ 
 
     return(f_par, f_perp)
 


### PR DESCRIPTION
This fixes a problem when a high pdi is used (~0.35). The code would generate a range of diameters based on a standard deviation calculated from the pdi. For high pdi, the diameter range would go negative, so the code forced the minimum to 0. The 0 value diameter caused a nan value in the differential cross section which therefore led to a nan value in the reflectance. I inserted a hardcoded small number to force the minimum diameter to instead of 0. 