### PR TITLE
Removed fine roughness parameter from det.calc_refl_trans()

### DIFF
--- a/montecarlo_tutorial.ipynb
+++ b/montecarlo_tutorial.ipynb
@@ -519,7 +519,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 11,
    "metadata": {
     "collapsed": false
    },
@@ -528,8 +528,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "R = 0.7856750514469373\n",
-      "T = 0.20131547151606885\n"
+      "R = 0.764572202901259\n",
+      "T = 0.19707275383599052\n"
      ]
     },
     {
@@ -596,13 +596,10 @@
     "z_low = sc.Quantity('0.0 um')\n",
     "cutoff = sc.Quantity('50 um')\n",
     "\n",
-    "# If there is coarse roughness, need to specify kz0_rotated and kz0_reflected. If there is fine roughness, \n",
-    "# need to specify n_matrix in addition to the fine roughness parameter\n",
+    "# If there is coarse roughness, need to specify kz0_rotated and kz0_reflected. \n",
     "reflectance, transmittance = det.calc_refl_trans(trajectories, cutoff, n_medium, n_sample, boundary,\n",
     "                                                 kz0_rot=kz0_rotated, \n",
-    "                                                 kz0_refl=kz0_reflected, \n",
-    "                                                 fine_roughness=fine_roughness, \n",
-    "                                                 n_matrix=n_matrix)\n",
+    "                                                 kz0_refl=kz0_reflected)\n",
     "print('R = '+ str(reflectance))\n",
     "print('T = '+ str(transmittance))"
    ]
@@ -641,7 +638,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 12,
    "metadata": {
     "collapsed": false
    },
@@ -771,7 +768,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 13,
    "metadata": {
     "collapsed": false,
     "scrolled": false
@@ -797,6 +794,15 @@
     "print('Reflectance = '+ str(reflectance))\n",
     "print('Transmittance = '+ str(transmittance))"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {

--- a/structcol/tests/test_detector.py
+++ b/structcol/tests/test_detector.py
@@ -731,8 +731,7 @@ def calc_montecarlo(nevents, ntrajectories, radius, n_particle, n_sample,
 
     # calculate R, T
     R, T = det.calc_refl_trans(trajectories, cutoff, n_medium, n_sample, 'film',
-                               kz0_rot=kz0_rotated, kz0_refl=kz0_reflected,
-                              fine_roughness=fine_roughness, n_matrix=n_matrix)
+                               kz0_rot=kz0_rotated, kz0_refl=kz0_reflected)
 
     return R, T
 

--- a/structcol/tests/test_montecarlo.py
+++ b/structcol/tests/test_montecarlo.py
@@ -728,8 +728,7 @@ def calc_montecarlo(nevents, ntrajectories, radius, n_particle, n_sample,
 
     # calculate R, T
     R, T = det.calc_refl_trans(trajectories, cutoff, n_medium, n_sample, 'film',
-                               kz0_rot=kz0_rotated, kz0_refl=kz0_reflected,
-                              fine_roughness=fine_roughness, n_matrix=n_matrix)
+                               kz0_rot=kz0_rotated, kz0_refl=kz0_reflected)
 
     return R, T
 


### PR DESCRIPTION
Previously, the Fresnel reflection of the incident light was calculated from n_medium to n_matrix when there was fine roughness in calc_refl_trans(). When there wasn't fine roughness, the Fresnel coefficient was calculated from n_medium to n_sample. Now, the Fresnel coefficient is always calculated from n_medium to n_sample, regardless of whether there's fine roughness. This is more consistent with the interpretation of the fine_roughness as a "correction" factor that corrects for the invalidity of effective medium theory at the interface. The previous implementation of Fresnel implied that fine roughness changed the physics of reflection, which is harder to argue if we consider the fine roughness to be simply a correction factor. 

Updated corresponding tests and tutorials. 