### PR TITLE
changed scipy.misc.factorial to scipy.special.factorial

### DIFF
--- a/structcol/model.py
+++ b/structcol/model.py
@@ -38,7 +38,7 @@ import pymie as pm
 from pymie import mie, size_parameter, index_ratio
 from pymie import multilayer_sphere_lib as msl
 import scipy
-from scipy.misc import factorial
+from scipy.special import factorial
 
 @ureg.check('[]', '[]', '[]', '[length]', '[length]', '[]')
 def reflection(n_particle, n_matrix, n_medium, wavelen, radius, volume_fraction,

--- a/structcol/phase_func_sphere.py
+++ b/structcol/phase_func_sphere.py
@@ -13,7 +13,7 @@ from scipy.stats import gaussian_kde
 from scipy.spatial.distance import cdist 
 import structcol as sc
 from . import montecarlo as mc
-from scipy.misc import factorial
+from scipy.special import factorial
 
 def get_exit_pos(norm_refl, norm_trans, radius):
     '''


### PR DESCRIPTION
scipy.misc.factorial is deprecated as of scipy 1.3.0 onward.