### PR TITLE
fixed error when using pip to install package

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,3 +50,6 @@ select = [
 "pymie/mie.py" = ["E741"]
 # for now, ignore "imported but unused" in __init__.py
 "__init__.py" = ["F401"]
+
+[tool.setuptools.packages.find]
+include = ["structcol"]


### PR DESCRIPTION
This PR fixes the error ` error: Multiple top-level packages discovered in a flat-layout` when using `pip` to install. Fixes #123 