### PR TITLE
Use vectorized mie

### DIFF
--- a/.github/workflows/lint_and_test.yml
+++ b/.github/workflows/lint_and_test.yml
@@ -47,6 +47,7 @@ jobs:
       with:
         environment-file: environment.yml
         miniforge-version: latest
+        conda-remove-defaults: "true"
     - name: Check out python-mie and install
       shell: bash -el {0}
       run: |

--- a/README.md
+++ b/README.md
@@ -8,17 +8,17 @@ package for Mie scattering calculations. To install:
 
 ```shell
 git clone https://github.com/manoharan-lab/python-mie.git
-pip install ./python-mie
+python -m pip install ./python-mie
 ```
 
 To remove:
 
 ```shell
-pip remove pymie
+python -m pip uninstall pymie
 ```
 
-You might want to first set up a virtual environment and install the pymie
-package there.
+You might want to first set up a conda environment (using the included
+`environment.yml` file) and install the `pymie` package in that environment.
 
 The original code was developed by Sofia Magkiriadou (with contributions from
 Jerome Fung and others) during her research [1,2] in the
@@ -44,5 +44,4 @@ Additional publications based on this code:
 
 3. Hwang, V.; Stephenson, A. B.; Barkley, S.; Brandt, S.; Xiao, M.; Aizenberg, J.; Manoharan, V. N. “Designing Angle-Independent Structural Colors Using Monte Carlo Simulations of Multiple Scattering.” *Proceedings of National Academy  Sciences* 118, no. 4 (2021): e2015551118. [doi:10.1073/pnas.2015551118](https://www.pnas.org/doi/abs/10.1073/pnas.2015551118).
 
-4. Hwang, V.\*; Stephenson, A. B.\*; Magkiriadou, S.; Park, J.-G.; Manoharan, V. N. “Effects of Multiple Scattering on Angle-Independent Structural Color in Disordered Colloidal Materials.” *Physical Review E* 101, no. 1 (2020): 012614. \*equal contribution [doi:10.1103/PhysRevE.101.012614](https://journals.aps.org/pre/abstract/10.1103/PhysRevE.101.012614). 
-
+4. Hwang, V.\*; Stephenson, A. B.\*; Magkiriadou, S.; Park, J.-G.; Manoharan, V. N. “Effects of Multiple Scattering on Angle-Independent Structural Color in Disordered Colloidal Materials.” *Physical Review E* 101, no. 1 (2020): 012614. \*equal contribution [doi:10.1103/PhysRevE.101.012614](https://journals.aps.org/pre/abstract/10.1103/PhysRevE.101.012614).

--- a/environment.yml
+++ b/environment.yml
@@ -1,7 +1,7 @@
 # dependencies for structural color package
 #
 # To use:
-#   conda env create -f .\environment.yml
+#   conda env create -f environment.yml
 # and then
 #   conda activate structcol
 #
@@ -12,7 +12,6 @@
 name: structcol
 channels:
   - conda-forge
-  - defaults
 dependencies:
   - python>=3.11
   - numpy
@@ -34,4 +33,3 @@ dependencies:
 
   # for installing other dependencies
   - pip
-

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "structcol"
-version = "0.3"
+version = "0.3.1"
 description = "Python package for modeling structural color"
 readme = "README.md"
 authors = [

--- a/structcol/model.py
+++ b/structcol/model.py
@@ -32,7 +32,6 @@ Physical Review E 90, no. 6 (2014): 62302. doi:10.1103/PhysRevE.90.062302
 
 import numpy as np
 from pymie import index_ratio, mie
-from pymie import multilayer_sphere_lib as msl
 from pymie import size_parameter
 from scipy.special import factorial
 from scipy.integrate import trapezoid
@@ -842,7 +841,10 @@ def polydisperse_form_factor(m, angles, diameters, concentration, pdi, wavelen,
             distr_array = np.tile(distr, [len(angles),1])
         angles_array = np.tile(angles, [len(diameter_range),1])
 
-        x_poly = size_parameter(wavelen, n_matrix, diameter_range/2)
+        # size parameter will be a 2D array [1, num_diameters]. Because this
+        # would be interpreted as a layered particle by pymie, we convert to a
+        # 1D array before looping
+        x_poly = size_parameter(wavelen, n_matrix, diameter_range/2)[0]
 
         form_factor = {}
         integrand = {}
@@ -1055,7 +1057,7 @@ def absorption_cross_section(form_type, m, diameters, n_matrix, x, wavelen,
         # if the index ratio m is an array with more than 1 element, it's a
         # multilayer particle
         if len(np.atleast_1d(m)) > 1:
-            coeffs = msl.scatcoeffs_multi(m, x)
+            coeffs = mie._scatcoeffs_multi(m, x)
             cabs_total = mie._cross_sections_complex_medium_sudiarta(coeffs[0],
                                                                      coeffs[1],
                                                                      x,

--- a/structcol/tests/test_structure.py
+++ b/structcol/tests/test_structure.py
@@ -92,7 +92,7 @@ def test_structure_factor_percus_yevick_core_shell():
     volume_fraction_cs = Quantity(np.array([volume_fraction.magnitude, volume_fraction_shell.magnitude]), '')
 
     n_sample_cs = ri.n_eff(n_particle_cs, n_matrix, volume_fraction_cs)
-    x_cs = size_parameter(wavelen, n_sample_cs, radius_cs[1]).flatten()
+    x_cs = size_parameter(wavelen, n_sample_cs, radius_cs[1])
     qd_cs = 4*x_cs*np.sin(angles/2)
     s_cs = structure.factor_py(qd_cs, np.sum(volume_fraction_cs))
 


### PR DESCRIPTION
This PR contains patches to make `structcol` work with the new vectorized `pymie` package (see manoharan-lab/python-mie#17).  No new functionality has been added  -- that will happen in subsequent releases.  This PR just gets the package working again. Also:
- `README.md` has been updated to show how to install `pymie` with pip. 
- The defaults channel has been removed from the environment file, since it is now commercial. We rely entirely on conda-forge.  GitHub Actions have been modified to prevent implicit addition of the defaults channel.
- Version number has been bumped to 0.3.1 to reflect this patch.